### PR TITLE
feat(quiz): 新增分段式答題進度條

### DIFF
--- a/src/pages/QuizPage.vue
+++ b/src/pages/QuizPage.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="quiz-page-16p">
+    <div class="quiz-progress-rail" role="progressbar" :aria-valuenow="answeredCount" :aria-valuemax="questions.length" aria-label="Quiz progress">
+      <div
+        v-for="(answer, i) in state.answers"
+        :key="i"
+        class="quiz-progress-segment"
+        :class="{ answered: answer >= -3 && answer <= 3 }"
+      ></div>
+    </div>
     <main class="quiz-main">
       <section class="hero">
         <h1>{{ t('quiz.heroTitle') }}</h1>
@@ -132,6 +140,7 @@ onMounted(() => {
   void ensureData()
 })
 
+
 const questionRefs = ref<HTMLElement[]>([])
 const pendingUnansweredIndex = ref<number | null>(null)
 let unansweredHighlightTimer: ReturnType<typeof setTimeout> | null = null
@@ -220,6 +229,28 @@ async function submitQuiz() {
   min-height: 100vh;
   background: #ffffff;
   color: #2d3436;
+}
+
+.quiz-progress-rail {
+  position: fixed;
+  top: 72px;
+  left: 0;
+  right: 0;
+  height: 7px;
+  z-index: 49;
+  display: flex;
+  gap: 2px;
+}
+
+.quiz-progress-segment {
+  flex: 1;
+  height: 100%;
+  background: #dde6ee;
+  transition: background-color 0.25s ease;
+}
+
+.quiz-progress-segment.answered {
+  background: #5ac8fa;
 }
 
 .quiz-main {
@@ -580,6 +611,13 @@ async function submitQuiz() {
 @media (max-width: 980px) {
   .step-cards {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .quiz-progress-rail {
+    top: 68px;
+    gap: 1px;
   }
 }
 


### PR DESCRIPTION
## 問題描述

測驗頁缺乏填答進度回饋，使用者在作答過程中無法得知目前完成幾題，也看不出是否有跳過未回答的題目。

因此在測驗頁 header 下方加入固定分段進度條，每個格子對應一道題目：
- 已作答顯示藍色（#5ac8fa），未作答顯示灰色，跳過的題目
- 在中間留下灰格，讓使用者一眼看出哪些題目尚未回答。

## 變更內容
  - `src/pages/QuizPage.vue`
    - 在 header 下方新增固定分段進度條（position: fixed; top: 72px）                                                                                         
    - 進度條由 39 個獨立格子組成，每格對應一道題目：
      - 已作答：淺藍色（#5ac8fa）
      - 未作答 / 跳過：灰色（#dde6ee）
    - 跳過的題目在中間留下灰格，使用者一眼可辨識哪些題尚未回答，不會與「尚未到達的題目」混淆
    - 手機版（≤768px）格子間距縮小至 1px，避免過於擁擠
    - 加入 `role="progressbar"` 及 `aria-valuenow` / `aria-valuemax` 無障礙屬性

## 測試

  - npm run build 通過，無編譯錯誤
  - 手動驗證：依序作答、中途跳題、補答跳過題目，確認格子顏色即時更新正確