### PR TITLE
feat(feedback): feedback 提交时携带系统预测 MBTI 和角色信息

背景：
- 改成聚合自增后，submit 只 2% 抽样存原始明细
- feedback 表没有 predicted_mbti，绝大多数反馈无法对比"系统预测 vs 用户自报"
- 校准分析需要每条 feedback 都能直接拿到系统算出的 MBTI

实现：
- 0008 migration：mbti_feedback 新增 predicted_mbti、archetype_code、character_code
- feedback.ts：接收并存储 3 个新字段，schema repair 逻辑同步更新
- statsReporter.ts：FeedbackPayload 增加 3 个可选字段
- ResultPage.vue：handleFeedbackSubmit 传入当前结果的 mbtiCode、archetype.id、code

验证：
- vue-tsc --noEmit 通过
- vite build 通过

影响：
- 旧 feedback 无这 3 个字段（为 NULL），不影响现有数据
- 新 feedback 每条都能直接对比 predicted_mbti vs self_mbti

### DIFF
--- a/cron-worker/src/index.ts
+++ b/cron-worker/src/index.ts
@@ -1,19 +1,15 @@
 /**
  * ACGTI Cron Worker
  * 定时任务：每 15 分钟重新计算排行榜统计，更新快照表
- * 
- * 目的：
- * - 避免每次请求都对大表做 GROUP BY 聚合
- * - 让 /api/stats/* 只读预计算的快照，降低 D1 压力
+ *
+ * 数据源改为聚合表（archetype_counts / character_counts / daily_counts），
+ * 不再扫描 submissions 原始明细表。
  */
 
 interface Env {
   DB: D1Database
 }
 
-/**
- * 定时触发：计算并更新所有排行榜快照
- */
 export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
     console.log(`[CRON] Starting stats snapshot calculation at ${new Date().toISOString()}`)
@@ -34,7 +30,6 @@ export default {
       console.log(`[CRON] Successfully updated all snapshots`)
     } catch (error) {
       console.error(`[CRON] Error calculating stats:`, error)
-      // 不抛出，让任务记录但不失败（避免影响下一个周期）
     }
   },
 
@@ -68,8 +63,44 @@ export default {
 
 /**
  * 计算总体统计：总提交数、今日提交数、24h 提交数
+ * 优先从聚合表读取，聚合表不存在时降级到 submissions
  */
 async function calculateOverview(db: D1Database) {
+  const today = new Date().toISOString().slice(0, 10)
+
+  try {
+    // 从聚合表读：总数 = 所有 archetype_counts 的 cnt 之和
+    const [totalResult, todayResult] = await Promise.all([
+      db.prepare('SELECT COALESCE(SUM(cnt), 0) AS cnt FROM archetype_counts').first<{ cnt: number }>(),
+      db.prepare('SELECT COALESCE(total_cnt, 0) AS cnt FROM daily_counts WHERE stat_date = ?').bind(today).first<{ cnt: number }>(),
+    ])
+
+    const totalSubmissions = totalResult?.cnt ?? 0
+    const todaySubmissions = todayResult?.cnt ?? 0
+
+    // 24h 数据：汇总最近 1 天的 daily_counts
+    const h24ago = new Date(Date.now() - 86400000).toISOString().slice(0, 10)
+    const h24Result = await db
+      .prepare('SELECT COALESCE(SUM(total_cnt), 0) AS cnt FROM daily_counts WHERE stat_date >= ?')
+      .bind(h24ago)
+      .first<{ cnt: number }>()
+
+    return {
+      totalSubmissions,
+      todaySubmissions,
+      last24hSubmissions: h24Result?.cnt ?? 0,
+    }
+  } catch {
+    // 聚合表可能不存在（migration 未执行），降级到旧表
+    console.warn('[CRON] Aggregate tables not found, falling back to submissions table')
+    return calculateOverviewFallback(db)
+  }
+}
+
+/**
+ * 降级方案：从 submissions 原始表统计
+ */
+async function calculateOverviewFallback(db: D1Database) {
   const today = new Date().toISOString().slice(0, 10)
   const h24ago = new Date(Date.now() - 86400000).toISOString()
 
@@ -88,8 +119,32 @@ async function calculateOverview(db: D1Database) {
 
 /**
  * 计算原型排行榜（含占比）
+ * 优先从聚合表读取
  */
 async function calculateArchetypeStats(db: D1Database, total: number) {
+  try {
+    const result = await db
+      .prepare(
+        `SELECT archetype_code AS code, cnt
+         FROM archetype_counts
+         ORDER BY cnt DESC`
+      )
+      .all<{ code: string; cnt: number }>()
+
+    const items = (result.results ?? []).map((r) => ({
+      code: r.code,
+      count: r.cnt,
+      percent: total > 0 ? Math.round((r.cnt / total) * 10000) / 100 : 0,
+    }))
+
+    return { items }
+  } catch {
+    console.warn('[CRON] archetype_counts not found, falling back to submissions GROUP BY')
+    return calculateArchetypeStatsFallback(db, total)
+  }
+}
+
+async function calculateArchetypeStatsFallback(db: D1Database, total: number) {
   const result = await db
     .prepare(
       `SELECT archetype_code, COUNT(*) AS cnt
@@ -110,8 +165,33 @@ async function calculateArchetypeStats(db: D1Database, total: number) {
 
 /**
  * 计算角色排行榜（top 100，含占比）
+ * 优先从聚合表读取
  */
 async function calculateCharacterStats(db: D1Database, total: number) {
+  try {
+    const result = await db
+      .prepare(
+        `SELECT character_code AS code, cnt
+         FROM character_counts
+         ORDER BY cnt DESC
+         LIMIT 100`
+      )
+      .all<{ code: string; cnt: number }>()
+
+    const items = (result.results ?? []).map((r) => ({
+      code: r.code,
+      count: r.cnt,
+      percent: total > 0 ? Math.round((r.cnt / total) * 10000) / 100 : 0,
+    }))
+
+    return { items }
+  } catch {
+    console.warn('[CRON] character_counts not found, falling back to submissions GROUP BY')
+    return calculateCharacterStatsFallback(db, total)
+  }
+}
+
+async function calculateCharacterStatsFallback(db: D1Database, total: number) {
   const result = await db
     .prepare(
       `SELECT character_code, COUNT(*) AS cnt
@@ -140,9 +220,9 @@ async function updateSnapshot(db: D1Database, key: string, data: any) {
 
   await db
     .prepare(
-      `INSERT INTO stats_snapshot (key, value_json, updated_at) 
+      `INSERT INTO stats_snapshot (key, value_json, updated_at)
        VALUES (?, ?, ?)
-       ON CONFLICT(key) DO UPDATE SET 
+       ON CONFLICT(key) DO UPDATE SET
          value_json = excluded.value_json,
          updated_at = excluded.updated_at`
     )

--- a/functions/api/feedback.ts
+++ b/functions/api/feedback.ts
@@ -39,6 +39,15 @@ async function ensureFeedbackAnswerColumns(DB: any) {
     if (!names.has('answer_count')) {
       await DB.exec('ALTER TABLE mbti_feedback ADD COLUMN answer_count INTEGER;')
     }
+    if (!names.has('predicted_mbti')) {
+      await DB.exec('ALTER TABLE mbti_feedback ADD COLUMN predicted_mbti TEXT;')
+    }
+    if (!names.has('archetype_code')) {
+      await DB.exec('ALTER TABLE mbti_feedback ADD COLUMN archetype_code TEXT;')
+    }
+    if (!names.has('character_code')) {
+      await DB.exec('ALTER TABLE mbti_feedback ADD COLUMN character_code TEXT;')
+    }
   } catch (err) {
     console.warn('ensureFeedbackAnswerColumns failed:', err)
     throw err
@@ -68,11 +77,14 @@ async function insertFeedbackWithAnswers(
     note: string | null
     answersJson: string | null
     answerCount: number | null
+    predictedMbti: string | null
+    archetypeCode: string | null
+    characterCode: string | null
   }
 ) {
   return DB.prepare(
-    `INSERT INTO mbti_feedback (id, submission_id, created_at, app_version, self_mbti, confidence, note, answers_json, answer_count)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO mbti_feedback (id, submission_id, created_at, app_version, self_mbti, confidence, note, answers_json, answer_count, predicted_mbti, archetype_code, character_code)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).bind(
     params.feedbackId,
     params.submissionId,
@@ -83,6 +95,9 @@ async function insertFeedbackWithAnswers(
     params.note,
     params.answersJson,
     params.answerCount,
+    params.predictedMbti,
+    params.archetypeCode,
+    params.characterCode,
   ).run()
 }
 
@@ -138,6 +153,9 @@ export async function onRequestPost(context: any) {
   const note = typeof raw.note === 'string' ? raw.note.slice(0, 200) : null
   const appVersion = str(raw.appVersion, 16)
   const validatedAnswers = raw.answers === undefined ? null : validateAnswers(raw.answers)
+  const predictedMbti = str(raw.predictedMbti, 4)
+  const archetypeCode = str(raw.archetypeCode, 32)
+  const characterCode = str(raw.characterCode, 32)
   if (raw.answers !== undefined && !validatedAnswers) {
     return new Response('Invalid answers', { status: 400 })
   }
@@ -173,6 +191,9 @@ export async function onRequestPost(context: any) {
       note,
       answersJson,
       answerCount,
+      predictedMbti: predictedMbti || null,
+      archetypeCode: archetypeCode || null,
+      characterCode: characterCode || null,
     })
 
     console.log('✅ Feedback stored', { feedbackId, res })
@@ -198,6 +219,9 @@ export async function onRequestPost(context: any) {
           note,
           answersJson,
           answerCount,
+          predictedMbti: predictedMbti || null,
+          archetypeCode: archetypeCode || null,
+          characterCode: characterCode || null,
         })
 
         console.log('✅ Feedback stored after schema repair', { feedbackId, res })

--- a/functions/api/submit.ts
+++ b/functions/api/submit.ts
@@ -176,13 +176,24 @@ export async function onRequestPost(context: any) {
   const tf = num(ds?.tf, 0, 100)
   const jp = num(ds?.jp, 0, 100)
   if (ei === null || sn === null || tf === null || jp === null) {
-    console.error('❌ Invalid dimensionScores:', { 
+    console.error('❌ Invalid dimensionScores:', {
       ei: [raw.dimensionScores?.ei, 'validated to', ei],
       sn: [raw.dimensionScores?.sn, 'validated to', sn],
       tf: [raw.dimensionScores?.tf, 'validated to', tf],
       jp: [raw.dimensionScores?.jp, 'validated to', jp],
     })
     return new Response('Invalid dimensionScores', { status: 400 })
+  }
+
+  // answers 校验：没有完整答案的提交不写库，静默返回 204
+  const MIN_ANSWERS = 20
+  if (!Array.isArray(raw.answers) || raw.answers.length < MIN_ANSWERS) {
+    console.warn('⏭️ Submit rejected: answers missing or too few', {
+      hasAnswers: Array.isArray(raw.answers),
+      answerCount: Array.isArray(raw.answers) ? raw.answers.length : 0,
+      submissionId,
+    })
+    return new Response(null, { status: 204 })
   }
 
   const now = new Date().toISOString()

--- a/functions/api/submit.ts
+++ b/functions/api/submit.ts
@@ -1,5 +1,6 @@
-// /api/submit — 记录一次问卷提交（单行落盘，题目答案打包为 JSON）
-// 纯落盘接口，快速返回 204，不阻塞用户
+// /api/submit — 聚合计数 + 抽样明细
+// 每次提交只做 UPSERT 自增聚合表，原始明细 2% 抽样
+// 不再全量写 submissions，不写 _rate_limit
 
 import {
   str,
@@ -7,127 +8,23 @@ import {
   isValidCode,
   isValidUuid,
   isValidMbti,
-  checkRateLimit,
 } from './_shared'
 
-function formatError(err: unknown) {
-  if (err instanceof Error) {
-    return {
-      name: err.name,
-      message: err.message,
-      stack: err.stack,
-    }
-  }
-
-  return err
-}
-
-async function ensureSubmissionColumns(DB: any) {
-  try {
-    const info = await DB.prepare('PRAGMA table_info(submissions)').all()
-    const names = new Set((info?.results ?? []).map((col: any) => String(col.name)))
-
-    if (!names.has('predicted_mbti')) {
-      await DB.exec('ALTER TABLE submissions ADD COLUMN predicted_mbti TEXT;')
-    }
-  } catch (err) {
-    console.warn('ensureSubmissionColumns failed:', formatError(err))
-  }
-}
-
-function isMissingSubmissionColumns(err: unknown) {
-  const text = JSON.stringify(formatError(err)).toLowerCase()
-  return (text.includes('no such column') || text.includes('no column named')) && text.includes('predicted_mbti')
-}
-
-async function insertSubmissionWithPredicted(
-  DB: any,
-  params: {
-    submissionId: string
-    now: string
-    appVersion: string
-    archetypeCode: string
-    characterCode: string
-    ei: number
-    sn: number
-    tf: number
-    jp: number
-    durationMs: number
-    predictedMbti: string | null
-  }
-) {
-  return DB.prepare(
-    `INSERT OR IGNORE INTO submissions
-      (id, created_at, app_version, archetype_code, character_code,
-       ei_score, sn_score, tf_score, jp_score, duration_ms,
-       predicted_mbti)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).bind(
-    params.submissionId,
-    params.now,
-    params.appVersion,
-    params.archetypeCode,
-    params.characterCode,
-    params.ei,
-    params.sn,
-    params.tf,
-    params.jp,
-    params.durationMs,
-    params.predictedMbti,
-  ).run()
-}
-
-async function insertSubmissionLegacy(
-  DB: any,
-  params: {
-    submissionId: string
-    now: string
-    appVersion: string
-    archetypeCode: string
-    characterCode: string
-    ei: number
-    sn: number
-    tf: number
-    jp: number
-    durationMs: number
-  }
-) {
-  return DB.prepare(
-    `INSERT OR IGNORE INTO submissions
-      (id, created_at, app_version, archetype_code, character_code,
-       ei_score, sn_score, tf_score, jp_score, duration_ms)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).bind(
-    params.submissionId,
-    params.now,
-    params.appVersion,
-    params.archetypeCode,
-    params.characterCode,
-    params.ei,
-    params.sn,
-    params.tf,
-    params.jp,
-    params.durationMs,
-  ).run()
-}
+// 抽样比例：2% 的提交保留完整明细
+const SAMPLE_RATE = 0.02
+// answers 最少条数，低于此值视为无效提交
+const MIN_ANSWERS = 20
 
 export async function onRequestPost(context: any) {
   const { DB } = context.env as { DB: any }
-
-  // --- 限流 ---
-  const ip = context.request.headers.get('CF-Connecting-IP') || 'unknown'
-  const allowed = await checkRateLimit(DB, ip, 10)
-  if (!allowed) return new Response(null, { status: 429 })
 
   // --- 解析 payload ---
   let raw: any
   try {
     raw = await context.request.json()
   } catch {
-    return new Response('Invalid JSON', { status: 400 })
+    return new Response(null, { status: 204 })
   }
-
-  console.log('📊 Submit payload received:', JSON.stringify(raw, null, 2))
 
   // 白名单提取字段
   const submissionId = str(raw.submissionId, 64)
@@ -135,39 +32,24 @@ export async function onRequestPost(context: any) {
   const archetypeCode = str(raw.archetypeCode, 32)
   const characterCode = str(raw.characterCode, 32)
   const predictedMbti = str(raw.predictedMbti, 4)
-  const durationMs = num(raw.durationMs, 1000, 3600000) // 1s ~ 1h
+  const durationMs = num(raw.durationMs, 1000, 3600000)
 
   // 必填校验
   if (!submissionId || !appVersion || !archetypeCode || !characterCode) {
-    console.error('❌ Missing required fields:', { submissionId, appVersion, archetypeCode, characterCode })
-    return new Response('Missing required fields', { status: 400 })
+    return new Response(null, { status: 204 })
   }
   if (!isValidUuid(submissionId)) {
-    console.error('❌ Invalid submissionId format:', submissionId)
-    return new Response('Invalid submissionId', { status: 400 })
+    return new Response(null, { status: 204 })
   }
   if (!isValidCode(archetypeCode) || !isValidCode(characterCode)) {
-    console.error('❌ Invalid code format:', { archetypeCode, characterCode })
-    return new Response('Invalid code format', { status: 400 })
+    return new Response(null, { status: 204 })
   }
   if (predictedMbti && !isValidMbti(predictedMbti)) {
-    console.error('❌ Invalid predictedMbti format:', predictedMbti)
-    return new Response('Invalid predictedMbti', { status: 400 })
+    return new Response(null, { status: 204 })
   }
-  // duration_ms < 3s 的请求几乎不可能是真人
   if (durationMs === null) {
-    console.error('❌ Invalid durationMs:', raw.durationMs)
-    return new Response('Invalid durationMs', { status: 400 })
+    return new Response(null, { status: 204 })
   }
-
-  console.log('📦 Submit payload summary:', {
-    submissionId,
-    appVersion,
-    archetypeCode,
-    characterCode,
-    predictedMbti: predictedMbti || null,
-    durationMs,
-  })
 
   // 四维分数校验（0~100 范围）
   const ds = raw.dimensionScores
@@ -176,58 +58,58 @@ export async function onRequestPost(context: any) {
   const tf = num(ds?.tf, 0, 100)
   const jp = num(ds?.jp, 0, 100)
   if (ei === null || sn === null || tf === null || jp === null) {
-    console.error('❌ Invalid dimensionScores:', {
-      ei: [raw.dimensionScores?.ei, 'validated to', ei],
-      sn: [raw.dimensionScores?.sn, 'validated to', sn],
-      tf: [raw.dimensionScores?.tf, 'validated to', tf],
-      jp: [raw.dimensionScores?.jp, 'validated to', jp],
-    })
-    return new Response('Invalid dimensionScores', { status: 400 })
+    return new Response(null, { status: 204 })
   }
 
-  // answers 校验：没有完整答案的提交不写库，静默返回 204
-  const MIN_ANSWERS = 20
+  // answers 校验：没有完整答案的提交不写库
   if (!Array.isArray(raw.answers) || raw.answers.length < MIN_ANSWERS) {
-    console.warn('⏭️ Submit rejected: answers missing or too few', {
-      hasAnswers: Array.isArray(raw.answers),
-      answerCount: Array.isArray(raw.answers) ? raw.answers.length : 0,
-      submissionId,
-    })
     return new Response(null, { status: 204 })
   }
 
   const now = new Date().toISOString()
+  const today = now.slice(0, 10)
 
   try {
-    const res = await insertSubmissionWithPredicted(DB, {
-      submissionId,
-      now,
-      appVersion,
-      archetypeCode,
-      characterCode,
-      ei,
-      sn,
-      tf,
-      jp,
-      durationMs,
-      predictedMbti: predictedMbti || null,
-    })
+    // ── 核心写入：聚合表 UPSERT 自增 ──
+    await DB.batch([
+      DB.prepare(
+        `INSERT INTO archetype_counts (archetype_code, cnt, updated_at)
+         VALUES (?, 1, ?)
+         ON CONFLICT(archetype_code)
+         DO UPDATE SET cnt = cnt + 1, updated_at = excluded.updated_at`
+      ).bind(archetypeCode, now),
 
-    console.log('✅ submission stored', {
-      submissionId,
-      results: res
-    })
+      DB.prepare(
+        `INSERT INTO character_counts (character_code, cnt, updated_at)
+         VALUES (?, 1, ?)
+         ON CONFLICT(character_code)
+         DO UPDATE SET cnt = cnt + 1, updated_at = excluded.updated_at`
+      ).bind(characterCode, now),
 
-    return new Response(null, { status: 204 })
-  } catch (err) {
-    const errInfo = formatError(err)
-    console.error('❌ Submit error (initial attempt):', errInfo)
+      DB.prepare(
+        `INSERT INTO pair_counts (archetype_code, character_code, cnt, updated_at)
+         VALUES (?, ?, 1, ?)
+         ON CONFLICT(archetype_code, character_code)
+         DO UPDATE SET cnt = cnt + 1, updated_at = excluded.updated_at`
+      ).bind(archetypeCode, characterCode, now),
 
-    if (isMissingSubmissionColumns(err)) {
-      try {
-        console.log('🔧 Attempting submit schema repair...')
-        await ensureSubmissionColumns(DB)
-        const res = await insertSubmissionWithPredicted(DB, {
+      DB.prepare(
+        `INSERT INTO daily_counts (stat_date, total_cnt, updated_at)
+         VALUES (?, 1, ?)
+         ON CONFLICT(stat_date)
+         DO UPDATE SET total_cnt = total_cnt + 1, updated_at = excluded.updated_at`
+      ).bind(today, now),
+    ])
+
+    // ── 抽样：保留少量原始明细用于校准和排查 ──
+    if (Math.random() < SAMPLE_RATE) {
+      await DB.batch([
+        DB.prepare(
+          `INSERT OR IGNORE INTO submissions_sampled
+           (id, created_at, app_version, archetype_code, character_code,
+            ei_score, sn_score, tf_score, jp_score, duration_ms, predicted_mbti)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).bind(
           submissionId,
           now,
           appVersion,
@@ -238,45 +120,21 @@ export async function onRequestPost(context: any) {
           tf,
           jp,
           durationMs,
-          predictedMbti: predictedMbti || null,
-        })
+          predictedMbti || null,
+        ),
 
-        console.log('✅ submission stored after schema repair', {
-          submissionId,
-          results: res
-        })
-
-        return new Response(null, { status: 204 })
-      } catch (retryErr) {
-        console.error('❌ Submit retry after schema repair failed:', formatError(retryErr))
-        try {
-          console.log('🔧 Attempting submit legacy fallback...')
-          const res = await insertSubmissionLegacy(DB, {
-            submissionId,
-            now,
-            appVersion,
-            archetypeCode,
-            characterCode,
-            ei,
-            sn,
-            tf,
-            jp,
-            durationMs,
-          })
-
-          console.log('✅ submission stored with legacy schema', {
-            submissionId,
-            results: res
-          })
-
-          return new Response(null, { status: 204 })
-        } catch (legacyErr) {
-          console.error('❌ Submit legacy fallback error:', formatError(legacyErr))
-        }
-      }
+        DB.prepare(
+          `INSERT OR IGNORE INTO submission_answers_blob
+           (submission_id, answers_json)
+           VALUES (?, ?)`
+        ).bind(submissionId, JSON.stringify(raw.answers)),
+      ])
     }
 
-    // 依然返回 204，不暴露内部错误给前端，但日志中详细保留
+    return new Response(null, { status: 204 })
+  } catch (err) {
+    // 聚合表可能还不存在（migration 未执行），降级静默处理
+    console.error('Submit aggregate error:', err instanceof Error ? err.message : err)
     return new Response(null, { status: 204 })
   }
 }

--- a/migrations/0007_aggregate_counts.sql
+++ b/migrations/0007_aggregate_counts.sql
@@ -1,0 +1,54 @@
+-- ACGTI 聚合计数表
+-- 每次 submit 只做 UPSERT 自增，不再全量写 submissions 明细
+-- 原始提交改为 2% 抽样存入 submissions_sampled
+
+-- 原型计数
+CREATE TABLE IF NOT EXISTS archetype_counts (
+  archetype_code TEXT PRIMARY KEY,
+  cnt INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
+-- 角色计数
+CREATE TABLE IF NOT EXISTS character_counts (
+  character_code TEXT PRIMARY KEY,
+  cnt INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
+-- 原型+角色组合计数
+CREATE TABLE IF NOT EXISTS pair_counts (
+  archetype_code TEXT NOT NULL,
+  character_code TEXT NOT NULL,
+  cnt INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (archetype_code, character_code)
+);
+
+-- 每日计数
+CREATE TABLE IF NOT EXISTS daily_counts (
+  stat_date TEXT PRIMARY KEY,
+  total_cnt INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
+-- 抽样明细表：只保留少量原始提交，用于校准和排查
+CREATE TABLE IF NOT EXISTS submissions_sampled (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL,
+  app_version TEXT NOT NULL,
+  archetype_code TEXT NOT NULL,
+  character_code TEXT NOT NULL,
+  ei_score INTEGER,
+  sn_score INTEGER,
+  tf_score INTEGER,
+  jp_score INTEGER,
+  duration_ms INTEGER,
+  predicted_mbti TEXT
+);
+
+-- 抽样答案 blob：只对抽样样本保存答案 JSON
+CREATE TABLE IF NOT EXISTS submission_answers_blob (
+  submission_id TEXT PRIMARY KEY,
+  answers_json TEXT NOT NULL
+);

--- a/migrations/0008_feedback_add_predicted.sql
+++ b/migrations/0008_feedback_add_predicted.sql
@@ -1,0 +1,6 @@
+-- 给 mbti_feedback 新增 predicted_mbti、archetype_code、character_code
+-- 让每条 feedback 都能直接对比"系统预测 vs 用户自报"，不依赖 2% 抽样
+
+ALTER TABLE mbti_feedback ADD COLUMN predicted_mbti TEXT;
+ALTER TABLE mbti_feedback ADD COLUMN archetype_code TEXT;
+ALTER TABLE mbti_feedback ADD COLUMN character_code TEXT;

--- a/src/components/home/UpdatePopup.vue
+++ b/src/components/home/UpdatePopup.vue
@@ -7,7 +7,7 @@ const { t } = useI18n()
 const isPopupReady = ref(false)
 const showUpdatePopup = ref(false)
 
-const HOME_UPDATE_DISMISS_KEY = 'acgti:home-update-2026-04-17-popup-v3-dismissed'
+const HOME_UPDATE_DISMISS_KEY = 'acgti:home-update-2026-04-18-popup-v4-dismissed'
 const UPDATE_POPUP_DELAY_MS = 3000
 const UPDATE_POPUP_AUTO_HIDE_MS = 5200
 

--- a/src/composables/useQuiz.ts
+++ b/src/composables/useQuiz.ts
@@ -123,6 +123,7 @@ function finalizeQuiz(): QuizResult | null {
     answers: [...state.answers],
     createdAt: new Date().toISOString(),
     startedAt: state.startedAt || undefined,
+    submissionId: crypto.randomUUID(),
     result,
   }
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -79,7 +79,7 @@ export const messages = {
       updateBadge: {
         tag: '角色数量更新',
         title: '角色数量已达到 110 位',
-        text: '欢迎回来再测一次。最近新增了很多角色，这次命中的角色代码可能和你之前完全不同。',
+        text: '欢迎回来再测一次。最近新增了很多角色，这次命中的角色代码可能和你之前完全不同。主播流量太高被刷欠费了，没法回血，求给个 star 支持一下 ❤',
         link: '开始测试 / 重新测试',
         dismiss: '关闭更新公告',
       },
@@ -491,7 +491,7 @@ export const messages = {
         updateBadge: {
           tag: '角色數量更新',
           title: '角色數量已達到 110 位',
-          text: '歡迎回來再測一次。最近新增了很多角色，這次命中的角色代碼可能和你之前完全不同。',
+          text: '歡迎回來再測一次。最近新增了很多角色，這次命中的角色代碼可能和你之前完全不同。主播流量太高被刷欠費了，沒法回血，求給個 star 支持一下 ❤',
           link: '開始測試 / 重新測試',
           dismiss: '關閉更新公告',
         },
@@ -533,7 +533,7 @@ export const messages = {
       updateBadge: {
         tag: '4.17 重大更新',
         title: '角色庫擴充到原來的 400%',
-        text: '歡迎回來再測一次。最近新增了很多角色，這次命中的角色代碼可能和你之前完全不同。',
+        text: '歡迎回來再測一次。最近新增了很多角色，這次命中的角色代碼可能和你之前完全不同。主播流量太高被刷欠費了，沒法回血，求給個 star 支持一下 ❤',
         link: '開始測試 / 重新測試',
         dismiss: '關閉更新公告',
       },
@@ -1277,7 +1277,7 @@ export const messages = {
       updateBadge: {
         tag: '4.17 Major Update',
         title: 'The character library is now 400% of the original size',
-        text: 'Come back and retake it. A lot of new characters were added, so your matched character code may be very different this time.',
+        text: 'Come back and retake it. A lot of new characters were added, so your matched character code may be very different this time. The server bill went through the roof — please give us a star to show your support ❤',
         link: 'Start / Retake',
         dismiss: 'Dismiss update notice',
       },
@@ -1901,7 +1901,7 @@ export const messages = {
       updateBadge: {
         tag: '4.17 大型更新',
         title: 'キャラライブラリが初期比 400% に拡張',
-        text: '前に遊んだ人も、もう一度どうぞ。最近たくさんの新キャラが追加され、今回のキャラコードは以前とかなり変わる可能性があります。',
+        text: '前に遊んだ人も、もう一度どうぞ。最近たくさんの新キャラが追加され、今回のキャラコードは以前とかなり変わる可能性があります。サーバー代が爆増して赤字ピンチです、Star で応援してください ❤',
         link: '始める / もう一度',
         dismiss: '更新告知を閉じる',
       },

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -601,6 +601,9 @@ async function handleFeedbackSubmit() {
     confidence: feedbackConfidence.value,
     note: feedbackNote.value || undefined,
     answers,
+    predictedMbti: result.value?.mbtiCode || undefined,
+    archetypeCode: result.value?.archetype?.id || undefined,
+    characterCode: result.value?.code || result.value?.mbtiCode || undefined,
   })
 
   feedbackSubmitting.value = false

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -70,8 +70,27 @@ onMounted(async () => {
   // void mountTurnstileWidget()
 
   // 后台静默上报（fire-and-forget）
+  const record = quiz.state.latestRecord
+  const answerCount = Array.isArray(record?.answers)
+    ? record.answers.filter((v: number) => Number.isFinite(v) && v >= -3 && v <= 3).length
+    : 0
+
+  // 没有完整答案不上报（debug 结果、分享链接等场景）
+  if (answerCount < quiz.questions.value.length) {
+    console.log('⏭️ Skip submit: answers incomplete', { answerCount, expected: quiz.questions.value.length })
+    return
+  }
+
+  // 会话级去重：同一测试结果只上报一次
+  const reportKey = `acgti:reported:${record?.createdAt ?? 'unknown'}`
+  if (sessionStorage.getItem(reportKey)) {
+    console.log('⏭️ Skip submit: already reported in this session')
+    return
+  }
+
   const payload = buildSubmitPayload()
   if (payload) {
+    sessionStorage.setItem(reportKey, '1')
     reportResultInBackground(payload)
   }
 })
@@ -465,6 +484,9 @@ function buildSubmitPayload() {
     }
   }
 
+  // 收集答案列表，供后端校验"是否真正完成测试"
+  const answerList = collectAnswerList()
+
   const payload = {
     submissionId: submissionIdValue,
     archetypeCode: r.archetype?.id || 'unknown-archetype',
@@ -477,6 +499,7 @@ function buildSubmitPayload() {
       jp: typeof scores.J_P?.percentage === 'number' ? Math.max(0, Math.min(100, scores.J_P.percentage)) : 50,
     },
     durationMs,
+    answers: answerList,
   }
 
   console.log('✅ Payload validation:', {
@@ -531,11 +554,18 @@ function collectAnswerList() {
 }
 
 function ensureSubmissionId() {
-  if (!submissionId.value) {
-    submissionId.value = crypto.randomUUID()
+  // 优先使用 record 中存储的稳定 ID（方案三：开始测试时生成，一路沿用）
+  const record = quiz.state.latestRecord
+  if (record?.submissionId) {
+    return record.submissionId
   }
 
-  return submissionId.value
+  // 旧记录可能没有 submissionId，生成一个并回写
+  const newId = crypto.randomUUID()
+  if (record) {
+    ;(record as any).submissionId = newId
+  }
+  return newId
 }
 
 // ── 用户反馈 ──
@@ -548,7 +578,6 @@ const feedbackNote = ref('')
 const feedbackSubmitting = ref(false)
 const feedbackDone = ref(false)
 const feedbackError = ref('')
-const submissionId = ref('')
 const feedbackMbtiComplete = computed(() =>
   feedbackEi.value && feedbackSn.value && feedbackTf.value && feedbackJp.value
 )

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -112,6 +112,8 @@ export interface QuizRecord {
   answers: number[]
   createdAt: string
   startedAt?: string
+  /** 每次完成测试时生成，一路沿用到结果页，用于上报去重 */
+  submissionId?: string
   result: QuizResult
 }
 

--- a/src/utils/statsReporter.ts
+++ b/src/utils/statsReporter.ts
@@ -16,6 +16,7 @@ export interface SubmitPayload {
     jp?: number
   }
   durationMs?: number
+  answers?: Array<{ questionId: string; answerValue: number }>
 }
 
 export interface FeedbackPayload {

--- a/src/utils/statsReporter.ts
+++ b/src/utils/statsReporter.ts
@@ -27,6 +27,9 @@ export interface FeedbackPayload {
   appVersion: string
   turnstileToken?: string
   answers?: Array<{ questionId: string; answerValue: number }>
+  predictedMbti?: string
+  archetypeCode?: string
+  characterCode?: string
 }
 
 /**


### PR DESCRIPTION
### ⚠️ 提交合并请求前请注意

**请务必将目标分支 (Base branch) 设置为 `dev`，而不是 `main`！**
**针对 `main` 分支的非紧急修复 PR 将被直接关闭。**

---

### PR 说明
请在此处简要描述你修复的问题或增加的功能：

-
