### PR TITLE
[codex] Fix runtime API base usage for stats requests

### DIFF
--- a/src/pages/StatsPage.vue
+++ b/src/pages/StatsPage.vue
@@ -379,11 +379,6 @@ onMounted(async () => {
 }
 
 /* Overview cards */
-overview-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
-}
 .overview-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/src/pages/StatsPage.vue
+++ b/src/pages/StatsPage.vue
@@ -8,6 +8,7 @@ import { useI18n } from '../i18n'
 import { getLocalizedCharacterName, getLocalizedCharacterSeries } from '../i18n/characters'
 import { resolvePublicAsset } from '../utils/characterVisuals'
 import { useSeo } from '../composables/useSeo'
+import { buildApiUrl } from '../utils/runtimeApi'
 
 useSeo({
   title: 'ACGTI 全局统计 - 测试数据概览',
@@ -147,9 +148,9 @@ function loadMoreCharacters() {
 onMounted(async () => {
   try {
     const [overviewRes, archetypesRes, charactersRes] = await Promise.all([
-      fetchStatsJson('/api/stats/overview'),
-      fetchStatsJson('/api/stats/archetypes'),
-      fetchStatsJson('/api/stats/characters'),
+      fetchStatsJson(buildApiUrl('/api/stats/overview')),
+      fetchStatsJson(buildApiUrl('/api/stats/archetypes')),
+      fetchStatsJson(buildApiUrl('/api/stats/characters')),
     ])
 
     const overviewJson = overviewRes
@@ -378,6 +379,11 @@ onMounted(async () => {
 }
 
 /* Overview cards */
+overview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
 .overview-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/src/utils/statsReporter.ts
+++ b/src/utils/statsReporter.ts
@@ -1,5 +1,7 @@
 // 统计上报工具 — fire-and-forget，绝不阻碍页面加载
 
+import { buildApiUrl } from './runtimeApi'
+
 /** 结果页真实统计数据 */
 export interface ResultStats {
   totalSubmissions: number
@@ -21,7 +23,7 @@ export async function fetchResultStats(
 ): Promise<ResultStats | null> {
   try {
     const params = new URLSearchParams({ character: characterCode, archetype: archetypeCode })
-    const res = await fetch(`/api/stats/result?${params.toString()}`)
+    const res = await fetch(buildApiUrl(`/api/stats/result?${params.toString()}`))
     if (!res.ok) return null
     const json = await res.json()
     return json.data ?? null
@@ -81,13 +83,13 @@ export function reportResultInBackground(payload: Omit<SubmitPayload, 'appVersio
     try {
       if (navigator.sendBeacon) {
         const blob = new Blob([body], { type: 'application/json' })
-        const queued = navigator.sendBeacon('/api/submit', blob)
+        const queued = navigator.sendBeacon(buildApiUrl('/api/submit'), blob)
         console.log('📨 sendBeacon queued:', queued)
         if (queued) return
       }
 
       // fallback
-      fetch('/api/submit', {
+      fetch(buildApiUrl('/api/submit'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body,
@@ -109,7 +111,7 @@ export function reportResultInBackground(payload: Omit<SubmitPayload, 'appVersio
  */
 export async function submitFeedback(payload: Omit<FeedbackPayload, 'appVersion'>): Promise<boolean> {
   try {
-    const res = await fetch('/api/feedback', {
+    const res = await fetch(buildApiUrl('/api/feedback'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ...payload, appVersion: APP_VERSION }),


### PR DESCRIPTION
## Summary

- Route result stats, submit, and feedback requests through the existing `buildApiUrl()` helper.
- Route the stats overview/archetype/character requests through `buildApiUrl()` as well.

## Why

The project already supports `VITE_API_BASE_URL` through `runtimeApi.ts`, but several stats-related calls still used hard-coded `/api/...` paths. In deployments where the frontend and API are separated, those requests can silently hit the wrong origin and break stats/feedback behavior.

## Validation

- Compared the fork branch against `main`; only `src/utils/statsReporter.ts` and `src/pages/StatsPage.vue` changed.
- Verified the remote branch has the corrected `buildApiUrl()` calls.

Note: I could not run the local build in this environment because `npm` is not installed on the available PATH.